### PR TITLE
Perbaiki metode getAnnualIncomeTax untuk mengatasi Long Method

### DIFF
--- a/src/lib/Employee.java
+++ b/src/lib/Employee.java
@@ -101,5 +101,4 @@ public class Employee {
 		}
 		
 		return TaxFunction.calculateTax(monthlySalary, otherMonthlyIncome, monthWorkingInYear, annualDeductible, spouseIdNumber.equals(""), childIdNumbers.size());
-	}
-	
+	}	


### PR DESCRIPTION
 menghitung berapa lama pegawai telah bekerja dalam setahun ke dalam metode terpisah, untuk memisahkan tanggung jawab dan membuat metode menjadi lebih terfokus.